### PR TITLE
add ability to disable a radio input

### DIFF
--- a/addon/components/amb-form-radio.js
+++ b/addon/components/amb-form-radio.js
@@ -4,7 +4,7 @@ export default Ember.Component.extend({
   layoutName: 'ember-ambitious-forms@components/amb-form-radio',
   tagName: 'label',
   classNames: 'amb-form-radio',
-  classNameBindings: 'checked:checked:unchecked',
+  classNameBindings: ['checked:checked:unchecked', 'disabled:disabled'],
 
   actions: {
     select () {

--- a/addon/templates/components/amb-form-radio-group.hbs
+++ b/addon/templates/components/amb-form-radio-group.hbs
@@ -1,5 +1,5 @@
 {{#each convertedOptions as |option|}}
-  {{#amb-form-radio name=name classNames=option.classNames value=option.value checked=option.isSelected action='selectConvertedOption'}}
+  {{#amb-form-radio name=name classNames=option.classNames value=option.value checked=option.isSelected action='selectConvertedOption' disabled=option.disabled}}
     <span class='amb-form-radio-text'>{{option.text}}</span>
     {{#if option.description}}
       <span class='amb-form-radio-description'>{{option.description}}</span>

--- a/addon/templates/components/amb-form-radio.hbs
+++ b/addon/templates/components/amb-form-radio.hbs
@@ -1,4 +1,4 @@
-<input class='amb-form-radio-input' type='radio' checked={{checked}} name={{name}} {{action 'select' preventDefault=false}}>
+<input class='amb-form-radio-input' type='radio' checked={{checked}} name={{name}} {{action 'select' preventDefault=false}} disabled={{disabled}}>
 {{#if hasBlock}}
   <span class='amb-form-radio-content'>{{yield}}</span>
 {{/if}}


### PR DESCRIPTION
This PR allows the developer to pass a disabled flag to the radio form group. It also adds a `disabled` class to the label. It is needed for the account opening tw application.