### PR TITLE
Swap label tag for div tag

### DIFF
--- a/addon/components/amb-form-field.js
+++ b/addon/components/amb-form-field.js
@@ -8,7 +8,7 @@ export default Ember.Component.extend(ConvertedOptions, {
   layoutName: 'ember-ambitious-forms@components/amb-form-field',
   service: Ember.inject.service('ember-ambitious-forms'),
 
-  tagName: 'label',
+  tagName: 'div',
   classNames: ['amb-form-field'],
   classNameBindings: ['readOnly:amb-form-field-read-only', '_errorStateClass'],
 


### PR DESCRIPTION
The amb-form-field component should use a `div` tag instead of a `label` tag as the `label` tag creates issues for the dateselect component. Specifically, having multiple inputs nested within a label tag will autofocus the form to the first input even when a later input is updated.